### PR TITLE
Include and use jaguar jsdoc template.

### DIFF
--- a/lib/actions/jsdoc.js
+++ b/lib/actions/jsdoc.js
@@ -36,7 +36,8 @@
           '--configure', 'jsdoc.conf.json',
           '--destination', 'build/docs/' + release,
           '--encoding', 'utf8',
-          '--recurse', true
+          '--recurse', true,
+          '--template', '../jaguarjs-jsdoc',
         ];
 
         spork(path.resolve(__dirname, '../../node_modules/.bin/jsdoc'), args, {exit: false, quiet: true, verbose: false})

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "gulp-sass": "^2.2.0",
     "handlebars": "^4.0.5",
     "inquirer": "^0.12.0",
+    "jaguarjs-jsdoc": "^0.0.1",
     "jsdoc": "^3.4.0",
     "lazypipe": "^1.0.1",
     "lodash": "^4.3.0",


### PR DESCRIPTION
This will use the jaguar template for the jsdoc output HTML.
